### PR TITLE
Update URLs to point to battlesnake.com from battlesnake.io.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # battlesnake-download-tool
-Chrome Extension to download game states for [battlesnake](https://play.battlesnake.io)
+Chrome Extension to download game states for [battlesnake](https://play.battlesnake.com)
 
 ## What does this do
 
@@ -9,6 +9,6 @@ This extension will allow you to download JSON inputs for snakes. Useful for bui
 
 Download [zip file](https://github.com/cbinners/battlesnake-download-tool/archive/1.0.zip) of repository, navigate to `chrome://extensions`, turn on developer mode, and select "Load Unpacked"
 
-Once this is loaded, go to a game on play.battlesnake.io, and use the extension to download input states for the snakes of your choice..
+Once this is loaded, go to a game on play.battlesnake.com, and use the extension to download input states for the snakes of your choice..
 
 Have fun and good luck!

--- a/background.js
+++ b/background.js
@@ -4,7 +4,7 @@ chrome.runtime.onInstalled.addListener(function() {
       {
         conditions: [
           new chrome.declarativeContent.PageStateMatcher({
-            pageUrl: { hostEquals: 'play.battlesnake.io' }
+            pageUrl: { hostEquals: 'play.battlesnake.com' }
           })
         ],
         actions: [new chrome.declarativeContent.ShowPageAction()]

--- a/download.js
+++ b/download.js
@@ -1,6 +1,6 @@
 function buildUrl(game, turn) {
   return (
-    'https://engine.battlesnake.io/games/' +
+    'https://engine.battlesnake.com/games/' +
     game +
     '/frames?offset=' +
     turn +
@@ -59,7 +59,7 @@ function transformFrameToInput(game, frameData) {
 window.__regex = /\/g\/(.+)?\//
 window.__gameId = window.location.href.match(window.__regex)[1]
 
-fetch('https://engine.battlesnake.io/games/' + window.__gameId, {
+fetch('https://engine.battlesnake.com/games/' + window.__gameId, {
   method: 'GET'
 })
   .then(res => res.json())

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "declarativeContent",
     "storage",
     "tabs",
-    "https://play.battlesnake.io/g/*"
+    "https://play.battlesnake.com/g/*"
   ],
   "background": {
     "scripts": ["background.js"],

--- a/popup.js
+++ b/popup.js
@@ -15,7 +15,7 @@ chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
   console.log('LOADED')
   let gameId = tabs[0].url.match(regex)[1]
 
-  fetch('https://engine.battlesnake.io/games/' + gameId, {
+  fetch('https://engine.battlesnake.com/games/' + gameId, {
     method: 'GET'
   })
     .then(res => res.json())


### PR DESCRIPTION
Battlesnake has updated their URLs from Battlesnake.io to Battlesnake.com, to account for this change an update was necessary to the URLs used internally by this extension.